### PR TITLE
Fix JWT authentication and remove pepper from password hashing

### DIFF
--- a/Authentication/Authentication/Models/MockUsersAPI.cs
+++ b/Authentication/Authentication/Models/MockUsersAPI.cs
@@ -14,7 +14,7 @@ namespace Authentication.Models
             public string DisplayName { get; init; }
             public string Email { get; init; }
             public string Organisation { get; init; }
-            public bool EmailVerified { get; init; }
+            public bool? EmailVerified { get; init; }
             public DateTime DateOfBirth { get; init; }
         }
 

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -75,7 +75,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
          /// <summary>
-        /// Retrieve a particular student's timelines
+        /// Retrieve a particular student timeline object
         /// </summary>
         /// <returns></returns>
         [HttpGet("student/timeline/{StudentTimelineId}")]
@@ -137,11 +137,52 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
+        /// Retrieve a particular team's timelines
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("team/{TeamName}")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the team and their corresponding timelines", typeof(TimelineTeam))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
+        public async Task<ObjectResult> GetTeams(string TeamName)
+        {
+
+            var Team = await TimelineService.GetTeamTimelines(new FindTimelineTeamRequest { TeamName = TeamName }).ConfigureAwait(false);
+
+            // Return Ok or 404 depending on whether the student exists
+            return Team is not null ?
+                Ok(value: Team) :
+                NotFound(value: $"Team with name '{TeamName}' was not found.");
+
+        }
+
+         /// <summary>
+        /// Retrieve a particular team timeline object
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("team/timeline/{TeamTimelineId}")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the team timeline", typeof(TimelineTeam))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team timeline was not found")]
+        public async Task<ObjectResult> GetATeamTimeline([FromRoute] string TeamTimelineId)
+        {
+
+            var TeamTimeline = await TimelineService.GetATeamTimeline(TeamTimelineId);
+
+            // Return Ok or 404 depending on whether the team timeline exists
+            return TeamTimeline is not null ?
+                Ok(value: TeamTimeline) :
+                NotFound(value: $"Timelinewith ID '{TeamTimelineId}' was not found.");
+
+        }
+
+
+        /// <summary>
         /// Add a team for the timeline
         /// </summary>
         /// <returns></returns>
         [Authorize]
-        [HttpPost("teams/create")]
+        [HttpPost("team/create")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The team was created successfully", typeof(TimelineTeam))]
         public async Task<ObjectResult> CreateTeam([FromBody] CreateTimelineTeamRequest Request)
         {
@@ -157,31 +198,12 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Retrieve a team from the timeline
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("teams/{TeamId}")]
-        [AllowAnonymous]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the team", typeof(TimelineTeam))]
-        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
-        public async Task<ObjectResult> GetTeam([FromRoute] string TeamId)
-        {
-            var Team = await TimelineService.GetTeam(new FindTimelineTeamRequest { TeamId = TeamId }).ConfigureAwait(false);
-
-            // Return Ok or 404 depending on whether the team exists
-            return Team is not null ?
-                Ok(value: Team) :
-                NotFound(value: $"Team with ID '{TeamId}' was not found.");
-
-        }
-
-        /// <summary>
         /// Retrieve a team from the timeline by their team id
         /// </summary>
         /// <param name="StudentId"></param>
         /// <returns></returns>
         //[Authorize]
-        [HttpDelete("teams/{TeamId}")]
+        [HttpDelete("team/{TeamId}")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully deleted the team", typeof(TimelineTeam))]
         [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
         public async Task<ObjectResult> DeleteTeam([FromRoute] string TeamId)
@@ -196,7 +218,7 @@ namespace ProjectX.WebAPI.Controllers
 
         }
 
-        [HttpPut("teams/update")]
+        [HttpPut("team/update")]
         [AllowAnonymous]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The team was updated successfully", typeof(TimelineTeam))]
         public async Task<ObjectResult> UpdateTeam([FromBody] UpdateTimelineTeamRequest Request)

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -22,7 +22,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Users can retrieve information about the complete student timeline from this endpoint
+        /// Retrieve all student timeline objects in the database
         /// </summary>
         /// <returns></returns>
         [HttpGet("student")]
@@ -34,7 +34,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Create a new student in the timeline
+        /// Create a new student timeline object
         /// </summary>
         /// <returns></returns>
         [Authorize]
@@ -94,7 +94,7 @@ namespace ProjectX.WebAPI.Controllers
 
         }
         /// <summary>
-        /// Delete a student from the timeline
+        /// Delete a student timeline object
         /// </summary>
         /// <param name="StudentId"></param>
         /// <returns></returns>
@@ -115,7 +115,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Update the student in the timeline
+        /// Update a student timeline object
         /// </summary>
         /// <returns></returns>
         //[Authorize]
@@ -137,7 +137,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Users can retrieve information about the complete team timeline from this endpoint
+        /// Retrieve all team timeline objects in the database
         /// </summary>
         /// <returns></returns>
         [HttpGet("team")]
@@ -191,7 +191,7 @@ namespace ProjectX.WebAPI.Controllers
 
 
         /// <summary>
-        /// Add a team for the timeline
+        /// Create a new team timeline object
         /// </summary>
         /// <returns></returns>
         [Authorize]
@@ -211,18 +211,18 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Retrieve a team from the timeline by their team id
+        /// Delete a team timeline object
         /// </summary>
-        /// <param name="StudentId"></param>
+        /// <param name="TeamTimelineId"></param>
         /// <returns></returns>
         //[Authorize]
         [HttpDelete("team/{TeamId}")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully deleted the team", typeof(TimelineTeam))]
         [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
-        public async Task<ObjectResult> DeleteTeam([FromRoute] string TeamId)
+        public async Task<ObjectResult> DeleteTeam([FromRoute] string TeamTimelineId)
         {
 
-            var DeletedTeam = await TimelineService.DeleteTeam(TeamId).ConfigureAwait(false);
+            var DeletedTeam = await TimelineService.DeleteTeam(TeamTimelineId).ConfigureAwait(false);
 
             // Return Ok or 404 depending on whether the team exists
             return DeletedTeam is not null ?
@@ -231,8 +231,13 @@ namespace ProjectX.WebAPI.Controllers
 
         }
 
+        /// <summary>
+        /// Update a team timeline object
+        /// </summary>
+        /// <returns></returns>
+        //[Authorize]
         [HttpPut("team/update")]
-        [AllowAnonymous]
+        [Authorize]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The team was updated successfully", typeof(TimelineTeam))]
         public async Task<ObjectResult> UpdateTeam([FromBody] UpdateTimelineTeamRequest Request)
         {

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -137,6 +137,19 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
+        /// Users can retrieve information about the complete team timeline from this endpoint
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("team")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully retrieved the information for the team timeline", typeof(CompanyTeamRestModel))]
+        public async Task<ObjectResult> GetAllTeamTimelines()
+        {
+            return Ok(value: await TimelineService.GetAllTeamTimelines().ConfigureAwait(false));
+        }
+
+
+        /// <summary>
         /// Retrieve a particular team's timelines
         /// </summary>
         /// <returns></returns>

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -27,13 +27,13 @@ namespace ProjectX.WebAPI.Controllers
         /// Users can retrieve information about the complete timeline from this endpoint
         /// </summary>
         /// <returns></returns>
-        [HttpGet()]
+        [HttpGet("student")]
         [AllowAnonymous]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully retrieved the information for the timeline", typeof(CompanyTeamRestModel))]
-        public async Task<ObjectResult> GetTimeline([FromQuery] GetTimelineRequest Request)
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully retrieved the information for the student timeline", typeof(CompanyTeamRestModel))]
+        public async Task<ObjectResult> GetStudentTimeline()
         {
 
-            return Ok(value: await TimelineService.GetTimeline(Request).ConfigureAwait(false));
+            return Ok(value: await TimelineService.GetStudentTimeline().ConfigureAwait(false));
 
         }
 
@@ -41,7 +41,7 @@ namespace ProjectX.WebAPI.Controllers
         /// Create a new student in the timeline
         /// </summary>
         /// <returns></returns>
-        //[Authorize]
+        [Authorize]
         [HttpPost("students/create")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The student was created successfully", typeof(TimelineStudent))]
         public async Task<ObjectResult> CreateStudent([FromBody] CreateTimelineStudentRequest Request)
@@ -100,10 +100,32 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Add a team for the timeline
+        /// Update the student in the timeline
         /// </summary>
         /// <returns></returns>
         //[Authorize]
+        [HttpPut("students/update")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "The student was updated successfully", typeof(TimelineStudent))]
+        public async Task<ObjectResult> UpdateStudent([FromBody] UpdateTimelineStudentRequest Request)
+        {
+
+            try
+            {
+                return Ok(value: await TimelineService.UpdateStudent(Request).ConfigureAwait(false));
+            }
+            catch (ArgumentException Ex)
+            {
+                return BadRequest(Ex.Message);
+            }
+
+        }
+
+        /// <summary>
+        /// Add a team for the timeline
+        /// </summary>
+        /// <returns></returns>
+        [Authorize]
         [HttpPost("teams/create")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The student was created successfully", typeof(TimelineStudent))]
         public async Task<ObjectResult> CreateTeam([FromBody] CreateTimelineTeamRequest Request)

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using ProjectX.WebAPI.Models.Chatbot;
 using ProjectX.WebAPI.Models.Database.Timeline;
-using ProjectX.WebAPI.Models.RestRequests.Request;
 using ProjectX.WebAPI.Models.RestRequests.Request.Timeline;
 using ProjectX.WebAPI.Models.RestRequests.Response;
 using ProjectX.WebAPI.Services;
@@ -24,7 +22,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Users can retrieve information about the complete timeline from this endpoint
+        /// Users can retrieve information about the complete student timeline from this endpoint
         /// </summary>
         /// <returns></returns>
         [HttpGet("student")]
@@ -33,7 +31,7 @@ namespace ProjectX.WebAPI.Controllers
         public async Task<ObjectResult> GetStudentTimeline()
         {
 
-            return Ok(value: await TimelineService.GetStudentTimeline().ConfigureAwait(false));
+            return Ok(value: await TimelineService.GetAllStudentTimelines().ConfigureAwait(false));
 
         }
 
@@ -42,7 +40,7 @@ namespace ProjectX.WebAPI.Controllers
         /// </summary>
         /// <returns></returns>
         [Authorize]
-        [HttpPost("students/create")]
+        [HttpPost("student/create")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The student was created successfully", typeof(TimelineStudent))]
         public async Task<ObjectResult> CreateStudent([FromBody] CreateTimelineStudentRequest Request)
         {
@@ -59,17 +57,17 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Retrieve a student from the timeline
+        /// Retrieve a particular student's timelines
         /// </summary>
         /// <returns></returns>
-        [HttpGet("students/{StudentId}")]
+        [HttpGet("student/{StudentId}")]
         [AllowAnonymous]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the student", typeof(TimelineStudent))]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the student and their corresponding timelines", typeof(TimelineStudent))]
         [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student was not found")]
-        public async Task<ObjectResult> GetStudent([FromRoute] string StudentId)
+        public async Task<ObjectResult> GetStudent(string StudentId)
         {
 
-            var Student = await TimelineService.GetStudent(new FindTimelineStudentRequest { StudentId = StudentId }).ConfigureAwait(false);
+            var Student = await TimelineService.GetStudentTimelines(new FindTimelineStudentRequest { StudentId = StudentId }).ConfigureAwait(false);
 
             // Return Ok or 404 depending on whether the student exists
             return Student is not null ?
@@ -78,13 +76,32 @@ namespace ProjectX.WebAPI.Controllers
 
         }
 
+         /// <summary>
+        /// Retrieve a particular student time
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("student/timeline/{StudentTimelineId}")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the student timeline", typeof(TimelineStudent))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student timeline was not found")]
+        public async Task<ObjectResult> GetAStudentTimeline([FromRoute] string StudentTimelineId)
+        {
+
+            var StudentTimeline = await TimelineService.GetAStudentTimeline(StudentTimelineId);
+
+            // Return Ok or 404 depending on whether the student exists
+            return StudentTimeline is not null ?
+                Ok(value: StudentTimeline) :
+                NotFound(value: $"Timelinewith ID '{StudentTimelineId}' was not found.");
+
+        }
         /// <summary>
         /// Delete a student from the timeline
         /// </summary>
         /// <param name="StudentId"></param>
         /// <returns></returns>
         //[Authorize]
-        [HttpDelete("students/{StudentId}")]
+        [HttpDelete("student/{StudentId}")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully deleted the student", typeof(TimelineStudent))]
         [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student was not found")]
         public async Task<ObjectResult> DeleteStudent([FromRoute] string StudentId)
@@ -104,7 +121,7 @@ namespace ProjectX.WebAPI.Controllers
         /// </summary>
         /// <returns></returns>
         //[Authorize]
-        [HttpPut("students/update")]
+        [HttpPut("student/update")]
         [AllowAnonymous]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The student was updated successfully", typeof(TimelineStudent))]
         public async Task<ObjectResult> UpdateStudent([FromBody] UpdateTimelineStudentRequest Request)
@@ -152,7 +169,7 @@ namespace ProjectX.WebAPI.Controllers
         [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student was not found")]
         public async Task<ObjectResult> GetTeam([FromRoute] string TeamId)
         {
-            
+
             var Team = await TimelineService.GetTeam(TeamId).ConfigureAwait(false);
 
             // Return Ok or 404 depending on whether the team exists
@@ -172,10 +189,10 @@ namespace ProjectX.WebAPI.Controllers
         public async Task<ObjectResult> FindTeam([FromRoute] string Trimester, [FromRoute] string TeamName)
         {
 
-            var Team = await TimelineService.FindTeam(new FindTimelineTeamRequest 
-            { 
-                TeamName = TeamName, 
-                Trimester = Trimester 
+            var Team = await TimelineService.FindTeam(new FindTimelineTeamRequest
+            {
+                TeamName = TeamName,
+                Trimester = Trimester
             }).ConfigureAwait(false);
 
             // Return Ok or 404 depending on whether the team exists

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -105,7 +105,7 @@ namespace ProjectX.WebAPI.Controllers
         /// <returns></returns>
         //[Authorize]
         [HttpPost("teams/create")]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "The student was created successfully", typeof(TimelineStudent))]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "The team was created successfully", typeof(TimelineTeam))]
         public async Task<ObjectResult> CreateTeam([FromBody] CreateTimelineTeamRequest Request)
         {
 
@@ -126,8 +126,8 @@ namespace ProjectX.WebAPI.Controllers
         /// <returns></returns>
         [HttpGet("teams/{TeamId}")]
         [AllowAnonymous]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the student", typeof(TimelineStudent))]
-        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student was not found")]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the team", typeof(TimelineTeam))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
         public async Task<ObjectResult> GetTeam([FromRoute] string TeamId)
         {
             
@@ -145,8 +145,8 @@ namespace ProjectX.WebAPI.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet("teams/{Trimester}/{TeamName}")]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the student", typeof(TimelineStudent))]
-        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student was not found")]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the team", typeof(TimelineTeam))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
         public async Task<ObjectResult> FindTeam([FromRoute] string Trimester, [FromRoute] string TeamName)
         {
 
@@ -170,8 +170,8 @@ namespace ProjectX.WebAPI.Controllers
         /// <returns></returns>
         //[Authorize]
         [HttpDelete("teams/{TeamId}")]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully deleted the student", typeof(TimelineStudent))]
-        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Student was not found")]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully deleted the team", typeof(TimelineTeam))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
         public async Task<ObjectResult> DeleteTeam([FromRoute] string TeamId)
         {
 
@@ -180,7 +180,24 @@ namespace ProjectX.WebAPI.Controllers
             // Return Ok or 404 depending on whether the student exists
             return DeletedTeam is not null ?
                 Ok(value: DeletedTeam) :
-                NotFound(value: $"Student with ID '{DeletedTeam}' was not found.");
+                NotFound(value: $"Team with ID '{DeletedTeam}' was not found.");
+
+        }
+
+        [HttpPut("teams/update")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "The team was updated successfully", typeof(TimelineTeam))]
+        public async Task<ObjectResult> UpdateTeam([FromBody] UpdateTimelineStudentRequest Request)
+        {
+
+            try
+            {
+                return Ok(value: await TimelineService.UpdateTeam(Request).ConfigureAwait(false));
+            }
+            catch (ArgumentException Ex)
+            {
+                return BadRequest(Ex.Message);
+            }
 
         }
 

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -77,7 +77,7 @@ namespace ProjectX.WebAPI.Controllers
         }
 
          /// <summary>
-        /// Retrieve a particular student time
+        /// Retrieve a particular student's timelines
         /// </summary>
         /// <returns></returns>
         [HttpGet("student/timeline/{StudentTimelineId}")]

--- a/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
+++ b/Monolith/ProjectX.WebAPI/Controllers/TimelineController.cs
@@ -27,21 +27,19 @@ namespace ProjectX.WebAPI.Controllers
         /// Users can retrieve information about the complete timeline from this endpoint
         /// </summary>
         /// <returns></returns>
-        [HttpGet()]
+        [HttpGet("student")]
         [AllowAnonymous]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully retrieved the information for the timeline", typeof(CompanyTeamRestModel))]
-        public async Task<ObjectResult> GetTimeline([FromQuery] GetTimelineRequest Request)
+        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully retrieved the information for the student timeline", typeof(CompanyTeamRestModel))]
+        public async Task<ObjectResult> GetStudentTimeline()
         {
-
-            return Ok(value: await TimelineService.GetTimeline(Request).ConfigureAwait(false));
-
+            return Ok(value: await TimelineService.GetStudentTimeline().ConfigureAwait(false));
         }
 
         /// <summary>
         /// Create a new student in the timeline
         /// </summary>
         /// <returns></returns>
-        //[Authorize]
+        [Authorize]
         [HttpPost("students/create")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The student was created successfully", typeof(TimelineStudent))]
         public async Task<ObjectResult> CreateStudent([FromBody] CreateTimelineStudentRequest Request)
@@ -100,10 +98,33 @@ namespace ProjectX.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Add a team for the timeline
+        // Add a team for the timeline
+        /// Update the student in the timeline
         /// </summary>
         /// <returns></returns>
         //[Authorize]
+        [HttpPut("students/update")]
+        [AllowAnonymous]
+        [SwaggerResponse(StatusCodes.Status200OK, description: "The student was updated successfully", typeof(TimelineStudent))]
+        public async Task<ObjectResult> UpdateStudent([FromBody] UpdateTimelineStudentRequest Request)
+        {
+
+            try
+            {
+                return Ok(value: await TimelineService.UpdateStudent(Request).ConfigureAwait(false));
+            }
+            catch (ArgumentException Ex)
+            {
+                return BadRequest(Ex.Message);
+            }
+
+        }
+
+        /// <summary>
+        /// Add a team for the timeline
+        /// </summary>
+        /// <returns></returns>
+        [Authorize]
         [HttpPost("teams/create")]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The team was created successfully", typeof(TimelineTeam))]
         public async Task<ObjectResult> CreateTeam([FromBody] CreateTimelineTeamRequest Request)
@@ -130,36 +151,13 @@ namespace ProjectX.WebAPI.Controllers
         [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
         public async Task<ObjectResult> GetTeam([FromRoute] string TeamId)
         {
-            
-            var Team = await TimelineService.GetTeam(TeamId).ConfigureAwait(false);
+
+            var Team = await TimelineService.GetTeam(new FindTimelineTeamRequest { TeamId = TeamId }).ConfigureAwait(false);
 
             // Return Ok or 404 depending on whether the team exists
             return Team is not null ?
                 Ok(value: Team) :
                 NotFound(value: $"Team with ID '{TeamId}' was not found.");
-
-        }
-
-        /// <summary>
-        /// Find a team from the timeline by their trimester and their team name
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("teams/{Trimester}/{TeamName}")]
-        [SwaggerResponse(StatusCodes.Status200OK, description: "Successfully found the team", typeof(TimelineTeam))]
-        [SwaggerResponse(StatusCodes.Status404NotFound, description: "Team was not found")]
-        public async Task<ObjectResult> FindTeam([FromRoute] string Trimester, [FromRoute] string TeamName)
-        {
-
-            var Team = await TimelineService.FindTeam(new FindTimelineTeamRequest 
-            { 
-                TeamName = TeamName, 
-                Trimester = Trimester 
-            }).ConfigureAwait(false);
-
-            // Return Ok or 404 depending on whether the team exists
-            return Team is not null ?
-                Ok(value: Team) :
-                NotFound(value: $"Team '{ TeamName }' in trimester '{ Trimester }' was not found.");
 
         }
 
@@ -177,7 +175,7 @@ namespace ProjectX.WebAPI.Controllers
 
             var DeletedTeam = await TimelineService.DeleteTeam(TeamId).ConfigureAwait(false);
 
-            // Return Ok or 404 depending on whether the student exists
+            // Return Ok or 404 depending on whether the team exists
             return DeletedTeam is not null ?
                 Ok(value: DeletedTeam) :
                 NotFound(value: $"Team with ID '{DeletedTeam}' was not found.");
@@ -187,7 +185,7 @@ namespace ProjectX.WebAPI.Controllers
         [HttpPut("teams/update")]
         [AllowAnonymous]
         [SwaggerResponse(StatusCodes.Status200OK, description: "The team was updated successfully", typeof(TimelineTeam))]
-        public async Task<ObjectResult> UpdateTeam([FromBody] UpdateTimelineStudentRequest Request)
+        public async Task<ObjectResult> UpdateTeam([FromBody] UpdateTimelineTeamRequest Request)
         {
 
             try

--- a/Monolith/ProjectX.WebAPI/Models/ApplicationHashSettings.cs
+++ b/Monolith/ProjectX.WebAPI/Models/ApplicationHashSettings.cs
@@ -1,0 +1,7 @@
+namespace ProjectX.WebAPI.Models
+{
+    public class ApplicationHashSettings
+    {
+        public string HashingPepper { get; set; }
+    }
+}

--- a/Monolith/ProjectX.WebAPI/Models/Database/Authentication/UserAuthenticationModel.cs
+++ b/Monolith/ProjectX.WebAPI/Models/Database/Authentication/UserAuthenticationModel.cs
@@ -24,9 +24,6 @@ namespace ProjectX.WebAPI.Models.Database.Authentication
         [FirestoreProperty]
         public string Salt { get; set; }
 
-        [FirestoreProperty]
-        public string Pepper { get; set; }
-
         [FirestoreProperty(ConverterType = typeof(UserRoleFirestoreConverter))]
         public UserRole Role { get; set; }
 

--- a/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineStudent.cs
+++ b/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineStudent.cs
@@ -10,8 +10,14 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
     [FirestoreData]
     public class TimelineStudent
     {
+        [FirestoreDocumentId]
+
+        public string TimelineStudentId { get; init; }
 
         [FirestoreDocumentId]
+        /// <summary>
+        /// The ID of the student
+        /// </summary>
         public string StudentId { get; init; }
 
         /// <summary>
@@ -21,42 +27,21 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
         public string FullName { get; set; }
 
         /// <summary>
-        /// A link to the students linked in profile
+        /// Title of achievement
         /// </summary>
         [FirestoreProperty]
-        public string LinkedInProfile { get; set; }
+        public string Title { get; set; }
 
         /// <summary>
-        /// A link to the users profile picture
+        /// Description of achievement
         /// </summary>
         [FirestoreProperty]
-        public string ProfilePicture { get; set; }
+        public string Description { get; set; }
 
         /// <summary>
-        /// The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        [FirestoreProperty]
-        public string Role { get; set; }
-
-        /// <summary>
-        /// Area where the student specialized
-        /// </summary>
-        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        [FirestoreProperty]
-        public string AreaOfSpecialization { get; set; }
-
-        /// <summary>
-        /// Any remarkable achievements of the student
+        /// Date at which the achievement of this student was added
         /// </summary>
         [FirestoreProperty]
-        public string RemarkableAchievements { get; set; }
-
-        /// <summary>
-        /// The id of the team that the student belongs to
-        /// </summary>
-        [FirestoreProperty]
-        public string[] Teams { get; set; }
-
+        public DateTime Date { get; set; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineStudent.cs
+++ b/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineStudent.cs
@@ -12,51 +12,42 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
     {
 
         [FirestoreDocumentId]
+
+        public string TimelineStudentId { get; init; }
+
+        [FirestoreDocumentId]
+        /// <summary>
+        /// The ID of the student
+        /// </summary>
         public string StudentId { get; init; }
+
 
         /// <summary>
         /// The full name of the student
         /// </summary>
         [FirestoreProperty]
+        
         public string FullName { get; set; }
 
         /// <summary>
-        /// A link to the students linked in profile
+        /// Title of achievement
         /// </summary>
         [FirestoreProperty]
-        public string LinkedInProfile { get; set; }
+
+        public string Title { get; set; }
 
         /// <summary>
-        /// A link to the users profile picture
+        /// Description of achievement
         /// </summary>
         [FirestoreProperty]
-        public string ProfilePicture { get; set; }
+
+        public string Description { get; set; }
 
         /// <summary>
-        /// The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        [FirestoreProperty]
-        public string Role { get; set; }
-
-        /// <summary>
-        /// Area where the student specialized
-        /// </summary>
-        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        [FirestoreProperty]
-        public string AreaOfSpecialization { get; set; }
-
-        /// <summary>
-        /// Any remarkable achievements of the student
+        /// Date at which the achievement of this student was added
         /// </summary>
         [FirestoreProperty]
-        public string RemarkableAchievements { get; set; }
 
-        /// <summary>
-        /// The id of the team that the student belongs to
-        /// </summary>
-        [FirestoreProperty]
-        public string[] Teams { get; set; }
-
+        public DateTime Date { get; set; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineStudent.cs
+++ b/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineStudent.cs
@@ -14,11 +14,11 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
 
         public string TimelineStudentId { get; init; }
 
-        [FirestoreDocumentId]
+        [FirestoreProperty]
         /// <summary>
         /// The ID of the student
         /// </summary>
-        public string StudentId { get; init; }
+        public string StudentId { get; set; }
 
         /// <summary>
         /// The full name of the student

--- a/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineTeam.cs
+++ b/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineTeam.cs
@@ -5,15 +5,9 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
     [FirestoreData]
     public class TimelineTeam
     {
-        
+
         [FirestoreDocumentId]
         public string TimelineTeamId { get; init; }
-
-        /// <summary>
-        /// The ID of the team
-        /// </summary>
-        [FirestoreDocumentId]
-        public string TeamId { get; init; }
 
         /// <summary>
         /// The name of the team
@@ -44,14 +38,6 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
         /// </summary>
         /// <example>T2 2022</example>
         [FirestoreProperty]
-        public string VideoLink { get; init; }
-
-        /// <summary>
-        /// A link to the project prototype
-        /// </summary>
-        /// <example>T2 2022</example>
-        [FirestoreProperty]
-        public string PrototypeLink { get; init; }
-
+        public string? VideoLink { get; init; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineTeam.cs
+++ b/Monolith/ProjectX.WebAPI/Models/Database/Timeline/TimelineTeam.cs
@@ -5,9 +5,12 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
     [FirestoreData]
     public class TimelineTeam
     {
+        
+        [FirestoreDocumentId]
+        public string TimelineTeamId { get; init; }
 
         /// <summary>
-        /// The unique Id of the team within the company
+        /// The ID of the team
         /// </summary>
         [FirestoreDocumentId]
         public string TeamId { get; init; }
@@ -15,29 +18,26 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
         /// <summary>
         /// The name of the team
         /// </summary>
-        /// <example>Team Avengers</example>
         [FirestoreProperty]
-        public string TeamName { get; init; }
+        public string TeamName { get; set; }
+
+        /// <summary>
+        /// Title of achievement
+        /// </summary>
+        [FirestoreProperty]
+        public string Title { get; set; }
 
         /// <summary>
         /// The description of the team
         /// </summary>
-        /// <example>Team Avengers</example>
         [FirestoreProperty]
-        public string Description { get; init; }
+        public string Description { get; set; }
 
         /// <summary>
-        /// A link to the team's logo
+        /// Date at which the achievement of this team was added
         /// </summary>
         [FirestoreProperty]
-        public string Logo { get; init; }
-
-        /// <summary>
-        /// The trimester that the team work in
-        /// </summary>
-        /// <example>T2 2022</example>
-        [FirestoreProperty]
-        public string Trimester { get; init; }
+        public DateTime Date { get; set; }
 
         /// <summary>
         /// The summary video for the team
@@ -52,13 +52,6 @@ namespace ProjectX.WebAPI.Models.Database.Timeline
         /// <example>T2 2022</example>
         [FirestoreProperty]
         public string PrototypeLink { get; init; }
-
-        /// <summary>
-        /// The trimester that the team work in
-        /// </summary>
-        /// <example>T2 2022</example>
-        [FirestoreProperty]
-        public string[] Mentors { get; init; }
 
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineStudentRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineStudentRequest.cs
@@ -4,6 +4,11 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
 {
     public record CreateTimelineStudentRequest
     {
+        /// <summary>
+        /// Required: The ID of the student
+        /// </summary>
+        /// <example>229823231</example>
+        public string StudentId { get; init; }
 
         /// <summary>
         /// Required: The full name of the student
@@ -12,47 +17,14 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
         public string FullName { get; init; }
 
         /// <summary>
-        /// Required: A link to the students linked in profile
+        /// Required: Title of the student's achievement
         /// </summary>
-        /// <example>https://au.linkedin.com/in/john-mcfluffy</example>
-        public string LinkedInProfile { get; init; }
+        /// <example>Successful elderly fall detection</example>
+        public string Title { get; init; }
 
         /// <summary>
-        /// Required: A picture of the student, base64 encoded
+        /// Required: A short description (max 250 words) of the student's achievement
         /// </summary>
-        public string ProfilePicture { get; init; }
-
-        /// <summary>
-        /// Required: The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        public string Role { get; init; }
-
-        /// <summary>
-        /// Required: Area where the student specialized
-        /// </summary>
-        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        public string AreaOfSpecialization { get; init; }
-
-        /// <summary>
-        /// Required: Any remarkable achievements of the student
-        /// </summary>
-        public string RemarkableAchievements { get; init; }
-
-        /// <summary>
-        /// Optional: The teams that the student belonged to
-        /// </summary>
-        public TimelineTeamReference[]? Teams { get; init; }
-
+        public string Description { get; init; }
     }
-
-    public record TimelineTeamReference
-    {
-
-        public string Trimester { get; set; }
-
-        public string TeamName { get; set; }
-
-    }
-
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineStudentRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineStudentRequest.cs
@@ -6,52 +6,27 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
     {
 
         /// <summary>
+        /// Required: The ID of the student
+        /// </summary>
+        /// <example>229823231</example>
+        public string StudentId { get; init; }
+
+        /// <summary>
         /// Required: The full name of the student
         /// </summary>
         /// <example>John McFluffy</example>
         public string FullName { get; init; }
 
         /// <summary>
-        /// Required: A link to the students linked in profile
-        /// </summary>
-        /// <example>https://au.linkedin.com/in/john-mcfluffy</example>
-        public string LinkedInProfile { get; init; }
-
-        /// <summary>
-        /// Required: A picture of the student, base64 encoded
-        /// </summary>
-        public string ProfilePicture { get; init; }
-
-        /// <summary>
-        /// Required: The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        public string Role { get; init; }
-
-        /// <summary>
-        /// Required: Area where the student specialized
+        /// Required: Title of the student's achievement
         /// </summary>
         /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        public string AreaOfSpecialization { get; init; }
+        public string Title { get; init; }
 
         /// <summary>
-        /// Required: Any remarkable achievements of the student
+        /// Required: A short description (max 250 words) of the student's achievement
         /// </summary>
-        public string RemarkableAchievements { get; init; }
-
-        /// <summary>
-        /// Optional: The teams that the student belonged to
-        /// </summary>
-        public TimelineTeamReference[]? Teams { get; init; }
-
-    }
-
-    public record TimelineTeamReference
-    {
-
-        public string Trimester { get; set; }
-
-        public string TeamName { get; set; }
+        public string Description { get; init; }
 
     }
 

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineTeamRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineTeamRequest.cs
@@ -5,11 +5,6 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
     public record CreateTimelineTeamRequest
     {
         /// <summary>
-        /// Required: The ID of the team
-        /// </summary>
-        public string TeamId { get; init; }
-
-        /// <summary>
         /// The name of the team
         /// </summary>
         public string TeamName { get; init; }
@@ -28,13 +23,6 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
         /// The summary video for the team
         /// </summary>
         /// <example>https://www.youtube.com/yourteamsummaryvideo</example>
-        public string VideoLink { get; init; }
-
-        /// <summary>
-        /// A link to the project prototype
-        /// </summary>
-        /// <example>https://api.gopherindustries.net/swagger/index.html</example>
-        public string PrototypeLink { get; init; }
-
+        public string? VideoLink { get; init; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineTeamRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/CreateTimelineTeamRequest.cs
@@ -4,29 +4,25 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
 {
     public record CreateTimelineTeamRequest
     {
+        /// <summary>
+        /// Required: The ID of the team
+        /// </summary>
+        public string TeamId { get; init; }
 
         /// <summary>
         /// The name of the team
         /// </summary>
-        /// <example>Team Avengers</example>
         public string TeamName { get; init; }
 
         /// <summary>
-        /// The description of the team
+        /// Required: Title of the team's achievement
         /// </summary>
-        /// <example>Team Avengers</example>
+        public string Title { get; init; }
+
+        /// <summary>
+        /// Required: A short description (max 250 words) of the student's achievement
+        /// </summary>
         public string Description { get; init; }
-
-        /// <summary>
-        /// The logo of the team, base64 encoded
-        /// </summary>
-        public string Logo { get; init; }
-
-        /// <summary>
-        /// The trimester that the team work in
-        /// </summary>
-        /// <example>T2 2022</example>
-        public string Trimester { get; init; }
 
         /// <summary>
         /// The summary video for the team
@@ -39,12 +35,6 @@ namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
         /// </summary>
         /// <example>https://api.gopherindustries.net/swagger/index.html</example>
         public string PrototypeLink { get; init; }
-
-        /// <summary>
-        /// The mentors that helped the team
-        /// </summary>
-        /// <example>Jenny Hummings, Olivia Ham</example>
-        public string[] Mentors { get; init; }
 
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/FindTimelineStudentRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/FindTimelineStudentRequest.cs
@@ -6,14 +6,14 @@
         /// <summary>
         /// Optional: Find a student by their student Id
         /// </summary>
-        /// <example>c3f4ce0d-393d-464a-8987-6d273146a76e</example>
-        public string? StudentId { get; init; }
+        /// <example>220211323</example>
+        public string? StudentId { get; set; }
 
         /// <summary>
         /// Optional: Find a student by their name
         /// </summary>
         /// <example>Alexander Hamilton</example>
-        public string? StudentName { get; init; }
+        public string? StudentName { get; set; }
 
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/FindTimelineTeamRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/FindTimelineTeamRequest.cs
@@ -2,10 +2,16 @@
 {
     public record FindTimelineTeamRequest
     {
+        /// <summary>
+        /// Optional: Find a student by their student Id
+        /// </summary>
+        /// <example>c3f4ce0d-393d-464a-8987-6d273146a76e</example>
+        public string? TeamId { get; init; }
 
-        public string Trimester { get; init; }
-
-        public string TeamName { get; init; }
-
+        /// <summary>
+        /// Optional: Find a student by their name
+        /// </summary>
+        /// <example>Alexander Hamilton</example>
+        public string? TeamName { get; init; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/GetTimelineRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/GetTimelineRequest.cs
@@ -4,21 +4,14 @@
     {
 
         /// <summary>
-        /// Required: Filter by the trimester
-        /// </summary>
-        /// <example>T2 2022</example>
-        public string Trimester { get; init; }
+        /// Required: type of timeline, specify either Student or Company
+        // <example>Student</example>
+        public TimelineType timelineType { get; init; }
+    }
 
-        /// <summary>
-        /// Optional: Filter by the team name. Seperate multiple with a comma
-        /// </summary>
-        /// <example>Team Avengers, ELT, Team Guardians</example>
-        public string? TeamName { get; init; }
-
-        /// <summary>
-        /// Optional: Filter by the student id
-        /// </summary>
-        public string? StudentId { get; init; }
-
+    public enum TimelineType
+    {
+        Student,
+        Company
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/GetTimelineRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/GetTimelineRequest.cs
@@ -2,23 +2,16 @@
 {
     public record GetTimelineRequest
     {
-
         /// <summary>
-        /// Required: Filter by the trimester
+        /// Required: type of timeline, specify either Student or Company
         /// </summary>
-        /// <example>T2 2022</example>
-        public string Trimester { get; init; }
+        /// <example>Student</example>
+        public TimelineType timelineType { get; init; }
+    }
 
-        /// <summary>
-        /// Optional: Filter by the team name. Seperate multiple with a comma
-        /// </summary>
-        /// <example>Team Avengers, ELT, Team Guardians</example>
-        public string? TeamName { get; init; }
-
-        /// <summary>
-        /// Optional: Filter by the student id
-        /// </summary>
-        public string? StudentId { get; init; }
-
+    public enum TimelineType
+    {
+        Student,
+        Company
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineStudentRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineStudentRequest.cs
@@ -1,24 +1,24 @@
 ﻿namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
 {
-    public record UpdateTimelineTeamRequest
+    public record UpdateTimelineStudentRequest
     {
         /// <summary>
         /// The ID of the team
         /// </summary>
-        public string TeamTimelineId { get; init; }
+        public string StudentTimelineId { get; init; }
 
         /// <summary>
         /// The id of the team
         /// </summary>
         /// 
-        public string? TeamId { get; init; }
+        public string? StudentId { get; init; }
 
 
         /// <summary>
         /// The full name of the team
         /// </summary>
         /// <example>John McFluffy</example>
-        public string? TeamName { get; init; }
+        public string? FullName { get; init; }
 
         /// <summary>
         /// Title of the student's achievement

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineStudentRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineStudentRequest.cs
@@ -2,6 +2,17 @@
 {
     public record UpdateTimelineStudentRequest
     {
+        /// <summary>
+        /// The ID of the student
+        /// </summary>
+        /// <example>is2lso20sna3msgJD8MD</example>
+        public string StudentTimelineId { get; init; }
+
+        /// <summary>
+        /// The id of the student
+        /// </summary>
+        /// <example>232313213</example>
+        public string? StudentId { get; init; }
 
         /// <summary>
         /// The full name of the student
@@ -10,47 +21,14 @@
         public string? FullName { get; init; }
 
         /// <summary>
-        /// A link to the students linked in profile
+        /// Title of the student's achievement
         /// </summary>
-        /// <example>https://au.linkedin.com/in/john-mcfluffy</example>
-        public string? LinkedInProfile { get; init; }
+        /// <example>Successful elderly fall detection</example>
+        public string? Title { get; init; }
 
         /// <summary>
-        /// A picture of the student, base64 encoded
+        /// A short description (max 250 words) of the student's achievement
         /// </summary>
-        public string? ProfilePicture { get; init; }
-
-        /// <summary>
-        /// The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        public string ?Role { get; init; }
-
-        /// <summary>
-        /// Area where the student specialized
-        /// </summary>
-        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        public string? AreaOfSpecialization { get; init; }
-
-        /// <summary>
-        /// Any remarkable achievements of the student
-        /// </summary>
-        public string? RemarkableAchievements { get; init; }
-
-        /// <summary>
-        /// The team name that the student worked on
-        /// </summary>
-        public string? TeamName { get; init; }
-
-        /// <summary>
-        /// The trimester of the given team. Required when TeamName is specified.
-        /// </summary>
-        public string? TeamTrimester { get; init; }
-
-        /// <summary>
-        /// The teams that the student belonged to
-        /// </summary>
-        public TimelineTeamReference[]? Teams { get; init; }
-
+        public string? Description { get; init; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineStudentRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineStudentRequest.cs
@@ -1,56 +1,34 @@
 ﻿namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
 {
-    public record UpdateTimelineStudentRequest
+    public record UpdateTimelineTeamRequest
     {
+        /// <summary>
+        /// The ID of the team
+        /// </summary>
+        public string TeamTimelineId { get; init; }
 
         /// <summary>
-        /// The full name of the student
+        /// The id of the team
+        /// </summary>
+        /// 
+        public string? TeamId { get; init; }
+
+
+        /// <summary>
+        /// The full name of the team
         /// </summary>
         /// <example>John McFluffy</example>
-        public string? FullName { get; init; }
-
-        /// <summary>
-        /// A link to the students linked in profile
-        /// </summary>
-        /// <example>https://au.linkedin.com/in/john-mcfluffy</example>
-        public string? LinkedInProfile { get; init; }
-
-        /// <summary>
-        /// A picture of the student, base64 encoded
-        /// </summary>
-        public string? ProfilePicture { get; init; }
-
-        /// <summary>
-        /// The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        public string ?Role { get; init; }
-
-        /// <summary>
-        /// Area where the student specialized
-        /// </summary>
-        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        public string? AreaOfSpecialization { get; init; }
-
-        /// <summary>
-        /// Any remarkable achievements of the student
-        /// </summary>
-        public string? RemarkableAchievements { get; init; }
-
-        /// <summary>
-        /// The team name that the student worked on
-        /// </summary>
         public string? TeamName { get; init; }
 
         /// <summary>
-        /// The trimester of the given team. Required when TeamName is specified.
+        /// Title of the student's achievement
         /// </summary>
-        public string? TeamTrimester { get; init; }
+        public string? Title { get; init; }
 
         /// <summary>
-        /// The teams that the student belonged to
+        /// A short description (max 250 words) of the student's achievement
         /// </summary>
-        public TimelineTeamReference[]? Teams { get; init; }
+        public string? Description { get; init; }
 
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineTeamRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineTeamRequest.cs
@@ -4,32 +4,29 @@
     {
 
         /// <summary>
-        /// The ID of the team
+        /// Required: The ID of the team
         /// </summary>
         public string TeamTimelineId { get; init; }
 
         /// <summary>
-        /// The id of the team
+        /// The name of the team
         /// </summary>
-        /// 
-        public string? TeamId { get; init; }
-
-
-        /// <summary>
-        /// The full name of the team
-        /// </summary>
-        /// <example>John McFluffy</example>
         public string? TeamName { get; init; }
 
         /// <summary>
-        /// Title of the student's achievement
+        /// Required: Title of the team's achievement
         /// </summary>
         public string? Title { get; init; }
 
         /// <summary>
-        /// A short description (max 250 words) of the student's achievement
+        /// Required: A short description (max 250 words) of the student's achievement
         /// </summary>
         public string? Description { get; init; }
 
+        /// <summary>
+        /// The summary video for the team
+        /// </summary>
+        /// <example>https://www.youtube.com/yourteamsummaryvideo</example>
+        public string? VideoLink { get; init; }
     }
 }

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineTeamRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineTeamRequest.cs
@@ -1,0 +1,56 @@
+﻿namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
+{
+    public record UpdateTimelineStudentRequest
+    {
+
+        /// <summary>
+        /// The full name of the student
+        /// </summary>
+        /// <example>John McFluffy</example>
+        public string? FullName { get; init; }
+
+        /// <summary>
+        /// A link to the students linked in profile
+        /// </summary>
+        /// <example>https://au.linkedin.com/in/john-mcfluffy</example>
+        public string? LinkedInProfile { get; init; }
+
+        /// <summary>
+        /// A picture of the student, base64 encoded
+        /// </summary>
+        public string? ProfilePicture { get; init; }
+
+        /// <summary>
+        /// The role of the user
+        /// </summary>
+        /// <example>Scrum Master, Product Owner, or Developer</example>
+        public string ?Role { get; init; }
+
+        /// <summary>
+        /// Area where the student specialized
+        /// </summary>
+        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
+        public string? AreaOfSpecialization { get; init; }
+
+        /// <summary>
+        /// Any remarkable achievements of the student
+        /// </summary>
+        public string? RemarkableAchievements { get; init; }
+
+        /// <summary>
+        /// The team name that the student worked on
+        /// </summary>
+        public string? TeamName { get; init; }
+
+        /// <summary>
+        /// The trimester of the given team. Required when TeamName is specified.
+        /// </summary>
+        public string? TeamTrimester { get; init; }
+
+        /// <summary>
+        /// The teams that the student belonged to
+        /// </summary>
+        public TimelineTeamReference[]? Teams { get; init; }
+
+    }
+}

--- a/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineTeamRequest.cs
+++ b/Monolith/ProjectX.WebAPI/Models/RestRequests/Request/Timeline/UpdateTimelineTeamRequest.cs
@@ -1,56 +1,35 @@
 ﻿namespace ProjectX.WebAPI.Models.RestRequests.Request.Timeline
 {
-    public record UpdateTimelineStudentRequest
+    public record UpdateTimelineTeamRequest
     {
 
         /// <summary>
-        /// The full name of the student
+        /// The ID of the team
+        /// </summary>
+        public string TeamTimelineId { get; init; }
+
+        /// <summary>
+        /// The id of the team
+        /// </summary>
+        /// 
+        public string? TeamId { get; init; }
+
+
+        /// <summary>
+        /// The full name of the team
         /// </summary>
         /// <example>John McFluffy</example>
-        public string? FullName { get; init; }
-
-        /// <summary>
-        /// A link to the students linked in profile
-        /// </summary>
-        /// <example>https://au.linkedin.com/in/john-mcfluffy</example>
-        public string? LinkedInProfile { get; init; }
-
-        /// <summary>
-        /// A picture of the student, base64 encoded
-        /// </summary>
-        public string? ProfilePicture { get; init; }
-
-        /// <summary>
-        /// The role of the user
-        /// </summary>
-        /// <example>Scrum Master, Product Owner, or Developer</example>
-        public string ?Role { get; init; }
-
-        /// <summary>
-        /// Area where the student specialized
-        /// </summary>
-        /// <example>Frontend Development, UI/UX Design, Artificial Intelligence, etc.</example>
-        public string? AreaOfSpecialization { get; init; }
-
-        /// <summary>
-        /// Any remarkable achievements of the student
-        /// </summary>
-        public string? RemarkableAchievements { get; init; }
-
-        /// <summary>
-        /// The team name that the student worked on
-        /// </summary>
         public string? TeamName { get; init; }
 
         /// <summary>
-        /// The trimester of the given team. Required when TeamName is specified.
+        /// Title of the student's achievement
         /// </summary>
-        public string? TeamTrimester { get; init; }
+        public string? Title { get; init; }
 
         /// <summary>
-        /// The teams that the student belonged to
+        /// A short description (max 250 words) of the student's achievement
         /// </summary>
-        public TimelineTeamReference[]? Teams { get; init; }
+        public string? Description { get; init; }
 
     }
 }

--- a/Monolith/ProjectX.WebAPI/Properties/launchSettings.json
+++ b/Monolith/ProjectX.WebAPI/Properties/launchSettings.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "ProjectX.WebAPI": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:80",
       "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:8000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Monolith/ProjectX.WebAPI/Services/IAuthenticationService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/IAuthenticationService.cs
@@ -79,12 +79,6 @@ namespace ProjectX.WebAPI.Services
       if (AuthModel == null)
         return false;
 
-      string salt = AuthModel.Salt;
-      string password = PlainTextPassword;
-      string pepper = appHashSettings.Value.HashingPepper;
-      string hash = AuthModel.HashedPassword;
-
-
       return BCrypt.Net.BCrypt.Verify(
           text: AuthModel.Salt + PlainTextPassword + appHashSettings.Value.HashingPepper,
           hash: AuthModel.HashedPassword,

--- a/Monolith/ProjectX.WebAPI/Services/IAuthenticationService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/IAuthenticationService.cs
@@ -2,232 +2,241 @@
 using ProjectX.WebAPI.Models.Database.Authentication;
 using System.Security.Cryptography;
 using System.Text;
+using ProjectX.WebAPI.Models;
+using Microsoft.Extensions.Options;
 
 namespace ProjectX.WebAPI.Services
 {
 
-    public interface IAuthenticationService
+  public interface IAuthenticationService
+  {
+
+    /// <summary>
+    /// Creates an authentication model using a plain text password. Stores it in the database.
+    /// </summary>
+    /// <param name="PlainTextPassword"></param>
+    /// <returns></returns>
+    public Task<UserAuthenticationModel> CreateUserAuthentication(UserModel User, string PlainTextPassword);
+
+    /// <summary>
+    /// Tries to retrieve the user authentication from the database.
+    /// </summary>
+    /// <param name="Filter"></param>
+    /// <returns></returns>
+    public Task<UserAuthenticationModel?> GetUserAuthentication(UserModel User);
+
+    /// <summary>
+    /// Tries to login as the user using the plain text password.
+    /// </summary>
+    /// <param name="User"></param>
+    /// <param name="PlainTextPassword"></param>
+    /// <returns></returns>
+    public Task<UserAuthenticationModel?> TryLogin(UserModel User, string PlainTextPassword);
+
+    public Task<RefreshTokenDatabaseEntry?> GetRefreshToken(UserModel User, string TokenId);
+
+    /// <summary>
+    /// Update a refresh token pertaining to a user
+    /// </summary>
+    /// <param name="User"></param>
+    /// <param name="RefreshToken"></param>
+    /// <returns></returns>
+    public Task<bool> AddRefreshToken(UserModel User, RefreshToken RefreshToken);
+
+    /// <summary>
+    /// Check if the user has the minimum authorization level
+    /// in order to do things like access an api service
+    /// </summary>
+    /// <param name="AuthModel"></param>
+    /// <param name="MinimumAuthorization"></param>
+    /// <returns></returns>
+    public bool HasPermission(UserAuthenticationModel AuthModel, UserRole MinimumAuthorization);
+
+  }
+
+  public class BCryptAuthenticationService : IAuthenticationService
+  {
+
+    private readonly IDatabaseService Database;
+    private readonly IMemoryCache cache;
+    private readonly IOptions<ApplicationHashSettings> appHashSettings;
+
+    private static readonly MemoryCacheEntryOptions _userAuthModelCacheOptions = new MemoryCacheEntryOptions()
+    {
+      Size = 400, // I did some very basic investigation and found UserModel's usually ~350 bytes in memory. 400 is buffer.
+      AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(6)
+    };
+
+    public BCryptAuthenticationService(IDatabaseService database, IMemoryCache cache, IOptions<ApplicationHashSettings> appHashSettings)
+    {
+      Database = database;
+      this.cache = cache;
+      this.appHashSettings = appHashSettings;
+    }
+
+    private bool MatchingPassword(string PlainTextPassword, UserAuthenticationModel? AuthModel)
+    {
+      if (AuthModel == null)
+        return false;
+
+      string salt = AuthModel.Salt;
+      string password = PlainTextPassword;
+      string pepper = appHashSettings.Value.HashingPepper;
+      string hash = AuthModel.HashedPassword;
+
+
+      return BCrypt.Net.BCrypt.Verify(
+          text: AuthModel.Salt + PlainTextPassword + appHashSettings.Value.HashingPepper,
+          hash: AuthModel.HashedPassword,
+          enhancedEntropy: true,
+          hashType: BCrypt.Net.HashType.SHA512);
+    }
+
+    public bool HasPermission(UserAuthenticationModel AuthModel, UserRole MinimumAuthorization)
     {
 
-        /// <summary>
-        /// Creates an authentication model using a plain text password. Stores it in the database.
-        /// </summary>
-        /// <param name="PlainTextPassword"></param>
-        /// <returns></returns>
-        public Task<UserAuthenticationModel> CreateUserAuthentication(UserModel User, string PlainTextPassword);
+      if (MinimumAuthorization == UserRole.Patient)
+        return true;
 
-        /// <summary>
-        /// Tries to retrieve the user authentication from the database.
-        /// </summary>
-        /// <param name="Filter"></param>
-        /// <returns></returns>
-        public Task<UserAuthenticationModel?> GetUserAuthentication(UserModel User);
+      if (MinimumAuthorization == UserRole.Caregiver)
+        return AuthModel.Role != UserRole.Patient;
 
-        /// <summary>
-        /// Tries to login as the user using the plain text password.
-        /// </summary>
-        /// <param name="User"></param>
-        /// <param name="PlainTextPassword"></param>
-        /// <returns></returns>
-        public Task<UserAuthenticationModel?> TryLogin(UserModel User, string PlainTextPassword);
+      if (MinimumAuthorization == UserRole.Admin)
+        return AuthModel.Role == UserRole.Admin;
 
-        public Task<RefreshTokenDatabaseEntry?> GetRefreshToken(UserModel User, string TokenId);
-
-        /// <summary>
-        /// Update a refresh token pertaining to a user
-        /// </summary>
-        /// <param name="User"></param>
-        /// <param name="RefreshToken"></param>
-        /// <returns></returns>
-        public Task<bool> AddRefreshToken(UserModel User, RefreshToken RefreshToken);
-
-        /// <summary>
-        /// Check if the user has the minimum authorization level 
-        /// in order to do things like access an api service
-        /// </summary>
-        /// <param name="AuthModel"></param>
-        /// <param name="MinimumAuthorization"></param>
-        /// <returns></returns>
-        public bool HasPermission(UserAuthenticationModel AuthModel, UserRole MinimumAuthorization);
+      throw new NotImplementedException("An error with reading permissions has occured.");
 
     }
 
-    public class BCryptAuthenticationService : IAuthenticationService
+    #region Database Interaction
+
+    public async Task<UserAuthenticationModel> CreateUserAuthentication(UserModel User, string PlainTextPassword)
     {
 
-        private readonly IDatabaseService Database;
-        private readonly IMemoryCache cache;
-        private static readonly MemoryCacheEntryOptions _userAuthModelCacheOptions = new MemoryCacheEntryOptions()
-        {
-            Size = 400, // I did some very basic investigation and found UserModel's usually ~350 bytes in memory. 400 is buffer.
-            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(6)
-        };
+      var UserAuth = new UserAuthenticationModel()
+      {
+        UserId = User.UserId,
+        Salt = Encoding.ASCII.GetString(RandomNumberGenerator.GetBytes(20)),
+      };
 
-        public BCryptAuthenticationService(IDatabaseService database, IMemoryCache cache)
-        {
-            Database = database;
-            this.cache = cache;
-        }
+      UserAuth.HashedPassword = BCrypt.Net.BCrypt.HashPassword(
+          inputKey: UserAuth.Salt + PlainTextPassword + appHashSettings.Value.HashingPepper,
+          salt: BCrypt.Net.BCrypt.GenerateSalt(workFactor: 10), // Work factor: Between 1 and 31
+          enhancedEntropy: true,
+          hashType: BCrypt.Net.HashType.SHA512);
 
-        
 
-        private bool MatchingPassword(string PlainTextPassword, UserAuthenticationModel? AuthModel)
-        {
+      UserAuth.Role = UserRole.Admin;
 
-            if (AuthModel == null)
-                return false;
+      var CreateRequest = await this.Database.SetDocument(
+                                                  CollectionPath: "UsersAuthentication",
+                                                  DocumentId: User.UserId,
+                                                  Value: UserAuth)
+                                             .ConfigureAwait(false);
 
-            return BCrypt.Net.BCrypt.Verify(
-                text: AuthModel.Salt + PlainTextPassword + AuthModel.Pepper,
-                hash: AuthModel.HashedPassword,
-                enhancedEntropy: true,
-                hashType: BCrypt.Net.HashType.SHA512);
+      // Add to cache
+      cache.Set(User.UserId + "-Auth", UserAuth, _userAuthModelCacheOptions);
 
-        }
-
-        public bool HasPermission(UserAuthenticationModel AuthModel, UserRole MinimumAuthorization)
-        {
-
-            if (MinimumAuthorization == UserRole.Patient)
-                return true;
-
-            if (MinimumAuthorization == UserRole.Caregiver)
-                return AuthModel.Role != UserRole.Patient;
-
-            if (MinimumAuthorization == UserRole.Admin)
-                return AuthModel.Role == UserRole.Admin;
-
-            throw new NotImplementedException("An error with reading permissions has occured.");
-
-        }
-
-        #region Database Interaction
-
-        public async Task<UserAuthenticationModel> CreateUserAuthentication(UserModel User, string PlainTextPassword)
-        {
-
-            var UserAuth = new UserAuthenticationModel()
-            {
-                UserId = User.UserId,
-                Salt = Encoding.ASCII.GetString(RandomNumberGenerator.GetBytes(20)),
-                Pepper = Encoding.ASCII.GetString(RandomNumberGenerator.GetBytes(20))
-            };
-
-            UserAuth.HashedPassword = BCrypt.Net.BCrypt.HashPassword(
-                inputKey: UserAuth.Salt + PlainTextPassword + UserAuth.Pepper,
-                salt: BCrypt.Net.BCrypt.GenerateSalt(workFactor: 10), // Work factor: Between 1 and 31
-                enhancedEntropy: true,
-                hashType: BCrypt.Net.HashType.SHA512);
-
-            var CreateRequest = await this.Database.SetDocument(
-                                                        CollectionPath: "UsersAuthentication",
-                                                        DocumentId: User.UserId,
-                                                        Value: User)
-                                                   .ConfigureAwait(false);
-
-            // Add to cache
-            cache.Set(User.UserId + "-Auth", UserAuth, _userAuthModelCacheOptions);
-
-            return UserAuth;
-
-        }
-
-        public async Task<UserAuthenticationModel?> GetUserAuthentication(UserModel User)
-        {
-
-            //
-            // Check if we have the auth cached
-            if (cache.TryGetValue(User.UserId + "-Auth", out UserAuthenticationModel UserAuth))
-                return UserAuth;
-
-            // Retrieve the users authentication from the database
-            
-            UserAuth = await Database.GetDocument<UserAuthenticationModel>(
-                                        CollectionPath: "UsersAuthentication",
-                                        DocumentId: User.UserId)
-                                     .ConfigureAwait(false);
-
-            cache.Set(User.UserId + "-Auth", UserAuth, _userAuthModelCacheOptions);
-
-            return UserAuth;
-
-        }
-
-        public async Task<RefreshTokenDatabaseEntry?> GetRefreshToken(UserModel User, string TokenId)
-        {
-
-            // Instruct database to delete any docs that aren't valid
-            await this.ValidateUserRefreshTokens(User).ConfigureAwait(false);
-
-            //
-            // Find the refresh token and return it
-            //return (await Database.Collection("UsersAuthentication")
-            //                      .Document(User.UserId)
-            //                      .Collection("RefreshTokens")
-            //                      .Document(TokenId)
-            //                      .GetSnapshotAsync()
-            //                      .ConfigureAwait(false))?
-            //                      .ConvertTo<RefreshTokenDatabaseEntry?>();
-            return (await this.Database.GetDocument<RefreshTokenDatabaseEntry>(
-                                                   CollectionPath: $"UsersAuthentication/{User.UserId}/RefreshTokens", TokenId));
-
-        }
-
-        public async Task<IReadOnlyList<RefreshTokenDatabaseEntry>> ValidateUserRefreshTokens(UserModel User)
-        {
-
-            // Instruct database to delete any docs that aren't valid
-            //var ExpieredDocs = (await Database.Collection("UsersAuthentication")
-            //                                  .Document(User.UserId)
-            //                                  .Collection("RefreshTokens")
-            //                                  .WhereLessThanOrEqualTo("ValidUntil", DateTime.UtcNow)
-            //                                  .GetSnapshotAsync()
-            //                                  .ConfigureAwait(false));
-            var ExpiredDocs = await this.Database.Collection("UsersAuthentication")
-                                                 .Document(User.UserId)
-                                                 .Collection("RefreshTokens")
-                                                 .WhereLessThanOrEqual(nameof(RefreshToken.ValidUntil), DateTime.UtcNow)
-                                                 .DeleteAsync<RefreshTokenDatabaseEntry>();
-
-            // Return all the deleted tokens
-            return ExpiredDocs;
-
-        }
-
-        public async Task<UserAuthenticationModel?> TryLogin(UserModel User, string PlainTextPassword)
-        {
-
-            var UserAuth = await this.GetUserAuthentication(User).ConfigureAwait(false);
-
-            return this.MatchingPassword(PlainTextPassword, UserAuth) ? UserAuth : null;
-
-        }
-
-        public async Task<bool> AddRefreshToken(UserModel User, RefreshToken RefreshToken)
-        {
-
-            // Because google is smart, it sees through our polymorphism and sees that the RefreshTokenDatabaseEntry
-            // is actually RefreshToken. Therefore, we just shallow copy the data over to a real instance
-            // of RefreshTokenDatabaseEntry lol
-
-            var DbEntry = new RefreshTokenDatabaseEntry
-            {
-                Secret = RefreshToken.Secret,
-                TokenId = RefreshToken.TokenId,
-                ValidUntil = RefreshToken.ValidUntil
-            };
-
-            return (await Database.Collection("UsersAuthentication")
-                                  .Document(User.UserId)
-                                  .Collection("RefreshTokens")
-                                  .Document(RefreshToken.TokenId)
-                                  .SetDocumentAsync(DbEntry)
-                                  .ConfigureAwait(false)) is not null;
-
-        }
-
-        #endregion
+      return UserAuth;
 
     }
+
+    public async Task<UserAuthenticationModel?> GetUserAuthentication(UserModel User)
+    {
+
+      //
+      // Check if we have the auth cached
+      if (cache.TryGetValue(User.UserId + "-Auth", out UserAuthenticationModel UserAuth))
+        return UserAuth;
+
+      // Retrieve the users authentication from the database
+
+      UserAuth = await Database.GetDocument<UserAuthenticationModel>(
+                                  CollectionPath: "UsersAuthentication",
+                                  DocumentId: User.UserId)
+                               .ConfigureAwait(false);
+
+      cache.Set(User.UserId + "-Auth", UserAuth, _userAuthModelCacheOptions);
+
+      return UserAuth;
+
+    }
+
+    public async Task<RefreshTokenDatabaseEntry?> GetRefreshToken(UserModel User, string TokenId)
+    {
+
+      // Instruct database to delete any docs that aren't valid
+      await this.ValidateUserRefreshTokens(User).ConfigureAwait(false);
+
+      //
+      // Find the refresh token and return it
+      //return (await Database.Collection("UsersAuthentication")
+      //                      .Document(User.UserId)
+      //                      .Collection("RefreshTokens")
+      //                      .Document(TokenId)
+      //                      .GetSnapshotAsync()
+      //                      .ConfigureAwait(false))?
+      //                      .ConvertTo<RefreshTokenDatabaseEntry?>();
+      return (await this.Database.GetDocument<RefreshTokenDatabaseEntry>(
+                                             CollectionPath: $"UsersAuthentication/{User.UserId}/RefreshTokens", TokenId));
+
+    }
+
+    public async Task<IReadOnlyList<RefreshTokenDatabaseEntry>> ValidateUserRefreshTokens(UserModel User)
+    {
+
+      // Instruct database to delete any docs that aren't valid
+      //var ExpieredDocs = (await Database.Collection("UsersAuthentication")
+      //                                  .Document(User.UserId)
+      //                                  .Collection("RefreshTokens")
+      //                                  .WhereLessThanOrEqualTo("ValidUntil", DateTime.UtcNow)
+      //                                  .GetSnapshotAsync()
+      //                                  .ConfigureAwait(false));
+      var ExpiredDocs = await this.Database.Collection("UsersAuthentication")
+                                           .Document(User.UserId)
+                                           .Collection("RefreshTokens")
+                                           .WhereLessThanOrEqual(nameof(RefreshToken.ValidUntil), DateTime.UtcNow)
+                                           .DeleteAsync<RefreshTokenDatabaseEntry>();
+
+      // Return all the deleted tokens
+      return ExpiredDocs;
+
+    }
+
+    public async Task<UserAuthenticationModel?> TryLogin(UserModel User, string PlainTextPassword)
+    {
+
+      var UserAuth = await this.GetUserAuthentication(User).ConfigureAwait(false);
+
+      return this.MatchingPassword(PlainTextPassword, UserAuth) ? UserAuth : null;
+
+    }
+
+    public async Task<bool> AddRefreshToken(UserModel User, RefreshToken RefreshToken)
+    {
+
+      // Because google is smart, it sees through our polymorphism and sees that the RefreshTokenDatabaseEntry
+      // is actually RefreshToken. Therefore, we just shallow copy the data over to a real instance
+      // of RefreshTokenDatabaseEntry lol
+
+      var DbEntry = new RefreshTokenDatabaseEntry
+      {
+        Secret = RefreshToken.Secret,
+        TokenId = RefreshToken.TokenId,
+        ValidUntil = RefreshToken.ValidUntil
+      };
+
+      return (await Database.Collection("UsersAuthentication")
+                            .Document(User.UserId)
+                            .Collection("RefreshTokens")
+                            .Document(RefreshToken.TokenId)
+                            .SetDocumentAsync(DbEntry)
+                            .ConfigureAwait(false)) is not null;
+
+    }
+
+    #endregion
+
+  }
 
 }

--- a/Monolith/ProjectX.WebAPI/Services/IDatabaseService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/IDatabaseService.cs
@@ -10,184 +10,199 @@ using System.Diagnostics;
 
 namespace ProjectX.WebAPI.Services
 {
-    public interface IDatabaseService
+  public interface IDatabaseService
+  {
+
+    public Task Initialize(IConfiguration Config);
+
+    public IDatabaseCollectionReference Collection(string CollectionPath);
+
+    public Task<IReadOnlyList<T>> GetAllDocuments<T>(string CollectionPath) where T : class;
+
+    public Task<T> GetDocument<T>(string CollectionPath, string DocumentId) where T : class;
+
+    public Task<IReadOnlyList<T>> GetDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class;
+
+    public Task<bool> SetDocument<T>(string CollectionPath, string DocumentId, T Value) where T : class;
+
+    public Task<bool> UpdateDocument<T>(string CollectionPath, string DocumentId, params (string, object)[] Updates) where T : class;
+
+    public Task<bool> DeleteDocument<T>(string CollectionPath, string DocumentId) where T : class;
+
+    public Task<bool> DeleteDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class;
+
+  }
+
+  /// <summary>
+  /// Provides access to the firestore database.
+  /// </summary>
+  public class FirestoreDatabase : IDatabaseService
+  {
+
+    private CancellationToken? DatabaseConnecting;
+    private FirestoreDb DatabaseReference;
+    private readonly ILogger<FirestoreDatabase> Logger;
+
+    private FirestoreDb Database
+    {
+      get
+      {
+        DatabaseConnecting?.WaitHandle.WaitOne();
+        return DatabaseReference;
+      }
+    }
+
+    public FirestoreDatabase(IConfiguration Config, ILogger<FirestoreDatabase> Logger)
     {
 
-        public Task Initialize(IConfiguration Config);
-
-        public IDatabaseCollectionReference Collection(string CollectionPath);
-
-        public Task<T> GetDocument<T>(string CollectionPath, string DocumentId) where T : class;
-
-        public Task<IReadOnlyList<T>> GetDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class;
-
-        public Task<bool> SetDocument<T>(string CollectionPath, string DocumentId, T Value) where T : class;
-
-        public Task<bool> UpdateDocument<T>(string CollectionPath, string DocumentId, params (string, object)[] Updates) where T : class;
-
-        public Task<bool> DeleteDocument<T>(string CollectionPath, string DocumentId) where T : class;
-
-        public Task<bool> DeleteDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class;
+      this.Logger = Logger;
 
     }
 
     /// <summary>
-    /// Provides access to the firestore database.
+    /// Create the initial connection to the database.
     /// </summary>
-    public class FirestoreDatabase : IDatabaseService
+    /// <returns>A constructed <see cref="FirestoreDb"/> class to access firestore through</returns>
+    public async Task Initialize(IConfiguration Config)
     {
 
-        private CancellationToken? DatabaseConnecting;
-        private FirestoreDb DatabaseReference;
-        private readonly ILogger<FirestoreDatabase> Logger;
+      //
+      // To change any of the authentication / login in database setup,
+      // please refer to this to change the project that this connects to.
+      // https://cloud.google.com/docs/authentication/production
+      //
 
-        private FirestoreDb Database { 
-            get
-            {
-                DatabaseConnecting?.WaitHandle.WaitOne();
-                return DatabaseReference;
-            } 
-        }
+      var TokenSource = new CancellationTokenSource();
+      this.DatabaseConnecting = TokenSource.Token;
 
-        public FirestoreDatabase(IConfiguration Config, ILogger<FirestoreDatabase> Logger)
-        {
+      //var DebugConnectionTimer = Stopwatch.StartNew();
 
-            this.Logger = Logger;
+      //var ff = new FirestoreClientBuilder()
+      //{
+      //    JsonCredentials = Config.GetJson("ApiKeys:FirestoreAccess")
+      //}.Build();
 
-        }
+      //this.Logger.LogInformation($"Taken {DebugConnectionTimer.ElapsedMilliseconds}ms to connect to firestore client");
 
-        /// <summary>
-        /// Create the initial connection to the database.
-        /// </summary>
-        /// <returns>A constructed <see cref="FirestoreDb"/> class to access firestore through</returns>
-        public async Task Initialize(IConfiguration Config)
-        {
+      //ff.GetDocument(new GetDocumentRequest
+      //{
+      //    Name = "projects/prototypeprojectx/databases/(default)/documents/Users/2acbf664-3915-43ae-b988-631a9bc16580"
+      //});
 
-            //
-            // To change any of the authentication / login in database setup,
-            // please refer to this to change the project that this connects to.
-            // https://cloud.google.com/docs/authentication/production
-            //
+      //this.Logger.LogInformation($"Taken {DebugConnectionTimer.ElapsedMilliseconds}ms to connect to firestore client and read doc");
 
-            var TokenSource = new CancellationTokenSource();
-            this.DatabaseConnecting = TokenSource.Token;
+      var ConnectionTimer = Stopwatch.StartNew();
 
-            //var DebugConnectionTimer = Stopwatch.StartNew();
+      // Connect to the firestore database
+      DatabaseReference = await new FirestoreDbBuilder()
+      {
+        //ProjectId = Config["ApiKeys:FirestoreAccess:project_id"],
+        //JsonCredentials = Config.GetJson("ApiKeys:FirestoreAccess"),
+        ProjectId = "sit-22t3-gopher-websit-a242043",
+        JsonCredentials = File.ReadAllText("projectx-credentials.json"),
+        //Endpoint = "https://firestore.googleapis.com",
+        GrpcChannelOptions = GrpcChannelOptions.Empty
+              .WithKeepAliveTime(TimeSpan.FromMinutes(1))
+              .WithKeepAliveTimeout(TimeSpan.FromMinutes(1))
+              .WithEnableServiceConfigResolution(false)
+              .WithMaxReceiveMessageSize(int.MaxValue),
+        GrpcAdapter = GrpcNetClientAdapter.Default
 
-            //var ff = new FirestoreClientBuilder()
-            //{
-            //    JsonCredentials = Config.GetJson("ApiKeys:FirestoreAccess")
-            //}.Build();
+      }.BuildAsync().ConfigureAwait(false);
 
-            //this.Logger.LogInformation($"Taken {DebugConnectionTimer.ElapsedMilliseconds}ms to connect to firestore client");
+      //Console.WriteLine($"Channel: { fb.Client.GrpcClient. }");
 
-            //ff.GetDocument(new GetDocumentRequest
-            //{
-            //    Name = "projects/prototypeprojectx/databases/(default)/documents/Users/2acbf664-3915-43ae-b988-631a9bc16580"
-            //});
+      this.Logger.LogInformation($"Taken {ConnectionTimer.ElapsedMilliseconds}ms to connect to firestore database");
 
-            //this.Logger.LogInformation($"Taken {DebugConnectionTimer.ElapsedMilliseconds}ms to connect to firestore client and read doc");
+      TokenSource.Cancel();
 
-            var ConnectionTimer = Stopwatch.StartNew();
+    }
 
-            // Connect to the firestore database
-            DatabaseReference = await new FirestoreDbBuilder()
-            {
-                //ProjectId = Config["ApiKeys:FirestoreAccess:project_id"],
-                //JsonCredentials = Config.GetJson("ApiKeys:FirestoreAccess"),
-                ProjectId = "sit-22t3-gopher-websit-a242043",
-                JsonCredentials = File.ReadAllText("projectx-credentials.json"),
-                //Endpoint = "https://firestore.googleapis.com",
-                GrpcChannelOptions = GrpcChannelOptions.Empty
-                    .WithKeepAliveTime(TimeSpan.FromMinutes(1))
-                    .WithKeepAliveTimeout(TimeSpan.FromMinutes(1))
-                    .WithEnableServiceConfigResolution(false)
-                    .WithMaxReceiveMessageSize(int.MaxValue),
-                GrpcAdapter = GrpcNetClientAdapter.Default
+    public async Task<IReadOnlyList<T>> GetAllDocuments<T>(string CollectionPath) where T : class
+    {
+      var querySnapshot = await this.Database.Collection(CollectionPath)
+                                           .GetSnapshotAsync()
+                                           .ConfigureAwait(false);
 
-            }.BuildAsync().ConfigureAwait(false);
+      return querySnapshot.Documents
+                           .Select(documentSnapshot => documentSnapshot.ConvertTo<T>())
+                           .ToList();
+    }
 
-            //Console.WriteLine($"Channel: { fb.Client.GrpcClient. }");
 
-            this.Logger.LogInformation($"Taken {ConnectionTimer.ElapsedMilliseconds}ms to connect to firestore database");
+    public async Task<T> GetDocument<T>(string CollectionPath, string DocumentId) where T : class
+    {
 
-            TokenSource.Cancel();
+      //
+      // Collection Path Example:
+      // Timeline/Collections/Students
+      // Users
+      // UsersAuthentication
 
-        }
+      var CollectionReference = this.Database.Collection(CollectionPath);
 
-        public async Task<T> GetDocument<T>(string CollectionPath, string DocumentId) where T : class
-        {
+      return (await CollectionReference.Document(DocumentId)
+                                       .GetSnapshotAsync()
+                                       .ConfigureAwait(false))
+                                       .ConvertTo<T>();
 
-            //
-            // Collection Path Example:
-            // Timeline/Collections/Students
-            // Users
-            // UsersAuthentication
+    }
 
-            var CollectionReference = this.Database.Collection(CollectionPath);
+    public IDatabaseCollectionReference Collection(string CollectionPath)
+    {
+      return new FirestoreDatabaseQueryBuilder(this.Database.Collection(CollectionPath));
+    }
 
-            return (await CollectionReference.Document(DocumentId)
-                                             .GetSnapshotAsync()
-                                             .ConfigureAwait(false))
-                                             .ConvertTo<T>();
+    public async Task<IReadOnlyList<T>> GetDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class
+    {
+      return await this.Collection(CollectionPath)
+                 .WhereIn(FieldPath.DocumentId.ToString(), DocumentIds)
+                 .GetAsync<T>();
+    }
 
-        }
+    public async Task<bool> SetDocument<T>(string CollectionPath, string DocumentId, T Value) where T : class
+    {
 
-        public IDatabaseCollectionReference Collection(string CollectionPath)
-        {
-            return new FirestoreDatabaseQueryBuilder(this.Database.Collection(CollectionPath));
-        }
+      var CollectionReference = this.Database.Collection(CollectionPath);
 
-        public async Task<IReadOnlyList<T>> GetDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class
-        {
-            return await this.Collection(CollectionPath)
-                       .WhereIn(FieldPath.DocumentId.ToString(), DocumentIds)
-                       .GetAsync<T>();
-        }
-
-        public async Task<bool> SetDocument<T>(string CollectionPath, string DocumentId, T Value) where T : class
-        {
-
-            var CollectionReference = this.Database.Collection(CollectionPath);
-
-            return (await CollectionReference.Document(DocumentId)
-                                             .SetAsync(Value)
-                                             .ConfigureAwait(false))
-                                             is not null;
-
-        }
-
-        public async Task<bool> UpdateDocument<T>(string CollectionPath, string DocumentId, params (string, object)[] Updates) where T : class
-        {
-
-            var CollectionReference = this.Database.Collection(CollectionPath);
-
-            return (await CollectionReference.Document(DocumentId)
-                                             .UpdateAsync(Updates.ToDictionary(x => x.Item1, x => x.Item2))
-                                             .ConfigureAwait(false))
-                                             is not null;
-
-        }
-
-        public async Task<bool> DeleteDocument<T>(string CollectionPath, string DocumentId) where T : class
-        {
-
-            return (await this.Database.Document($"{CollectionPath}/{DocumentId}")
-                                       .DeleteAsync()
+      return (await CollectionReference.Document(DocumentId)
+                                       .SetAsync(Value)
                                        .ConfigureAwait(false))
                                        is not null;
 
-        }
-
-        public async Task<bool> DeleteDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class
-        {
-
-            var Batch = this.Database.StartBatch();
-            foreach (var DocumentId in DocumentIds)
-                Batch.Delete(this.Database.Document($"{CollectionPath}/{DocumentId}"));
-
-            return (await Batch.CommitAsync()) is not null;
-
-        }
     }
+
+    public async Task<bool> UpdateDocument<T>(string CollectionPath, string DocumentId, params (string, object)[] Updates) where T : class
+    {
+
+      var CollectionReference = this.Database.Collection(CollectionPath);
+
+      return (await CollectionReference.Document(DocumentId)
+                                       .UpdateAsync(Updates.ToDictionary(x => x.Item1, x => x.Item2))
+                                       .ConfigureAwait(false))
+                                       is not null;
+
+    }
+
+    public async Task<bool> DeleteDocument<T>(string CollectionPath, string DocumentId) where T : class
+    {
+
+      return (await this.Database.Document($"{CollectionPath}/{DocumentId}")
+                                 .DeleteAsync()
+                                 .ConfigureAwait(false))
+                                 is not null;
+
+    }
+
+    public async Task<bool> DeleteDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class
+    {
+
+      var Batch = this.Database.StartBatch();
+      foreach (var DocumentId in DocumentIds)
+        Batch.Delete(this.Database.Document($"{CollectionPath}/{DocumentId}"));
+
+      return (await Batch.CommitAsync()) is not null;
+
+    }
+  }
 }

--- a/Monolith/ProjectX.WebAPI/Services/IDatabaseService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/IDatabaseService.cs
@@ -17,6 +17,8 @@ namespace ProjectX.WebAPI.Services
 
         public IDatabaseCollectionReference Collection(string CollectionPath);
 
+        public Task<IReadOnlyList<T>> GetAllDocuments<T>(string CollectionPath) where T : class;
+
         public Task<T> GetDocument<T>(string CollectionPath, string DocumentId) where T : class;
 
         public Task<IReadOnlyList<T>> GetDocuments<T>(string CollectionPath, IEnumerable<string> DocumentIds) where T : class;
@@ -113,6 +115,15 @@ namespace ProjectX.WebAPI.Services
 
             TokenSource.Cancel();
 
+        }
+
+        public async Task<IReadOnlyList<T>> GetAllDocuments<T>(string CollectionPath) where T : class
+        {
+            var querySnapshot = await this.Database.Collection(CollectionPath)
+                                                 .GetSnapshotAsync()
+                                                 .ConfigureAwait(false);
+
+            return querySnapshot.Documents.Select(documentSnapshot => documentSnapshot.ConvertTo<T>()).ToList();
         }
 
         public async Task<T> GetDocument<T>(string CollectionPath, string DocumentId) where T : class

--- a/Monolith/ProjectX.WebAPI/Services/IDatabaseService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/IDatabaseService.cs
@@ -96,7 +96,7 @@ namespace ProjectX.WebAPI.Services
                 //ProjectId = Config["ApiKeys:FirestoreAccess:project_id"],
                 //JsonCredentials = Config.GetJson("ApiKeys:FirestoreAccess"),
                 ProjectId = "sit-22t3-gopher-websit-a242043",
-                JsonCredentials = File.ReadAllText("sit-22t3-gopher-websit-a242043-e283fd98b08e.json"),
+                JsonCredentials = File.ReadAllText("projectx-credentials.json"),
                 //Endpoint = "https://firestore.googleapis.com",
                 GrpcChannelOptions = GrpcChannelOptions.Empty
                     .WithKeepAliveTime(TimeSpan.FromMinutes(1))

--- a/Monolith/ProjectX.WebAPI/Services/ITimelineService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/ITimelineService.cs
@@ -7,306 +7,275 @@ using ProjectX.WebAPI.Models.RestRequests.Response;
 
 namespace ProjectX.WebAPI.Services
 {
-    public interface ITimelineService
+  public interface ITimelineService
+  {
+
+    public Task<IReadOnlyList<TimelineStudent>> GetStudentTimeline();
+
+    /// <summary>
+    /// Creates a new student in the timeline
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <exception cref="ArgumentException"/>
+    /// <returns></returns>
+    public Task<TimelineStudent> CreateStudent(CreateTimelineStudentRequest Request);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <exception cref="ArgumentException"/>
+    /// <returns></returns>
+    public Task<TimelineStudent?> GetStudent(FindTimelineStudentRequest Request);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <returns></returns>
+    public Task<TimelineStudent?> DeleteStudent(string StudentTimelineId);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <returns></returns>
+    public Task<TimelineStudent?> UpdateStudent(UpdateTimelineStudentRequest Request);
+
+    /// <summary>
+    /// Creates a new student in the timeline
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <exception cref="ArgumentException"/>
+    /// <returns></returns>
+    public Task<TimelineTeam> CreateTeam(CreateTimelineTeamRequest Request);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <returns></returns>
+    public Task<TimelineTeam?> GetTeam(string TeamId);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="Request"></param>
+    /// <returns></returns>
+    public Task<TimelineTeam?> FindTeam(FindTimelineTeamRequest Request);
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    public Task<TimelineTeam?> DeleteTeam(string TeamId);
+
+  }
+
+  public class TimelineService : ITimelineService
+  {
+
+    private readonly IMemoryCache Cache;
+    private readonly IDatabaseService Database;
+
+    private static readonly MemoryCacheEntryOptions _timelinePersonCacheOptions = new MemoryCacheEntryOptions()
     {
+      Size = 400,
+      AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30)
+    };
 
-        public Task<IReadOnlyList<CompanyTeamRestModel>> GetTimeline(GetTimelineRequest Request);
+    public TimelineService(IDatabaseService database, IMemoryCache cache)
+    {
+      Database = database;
+      Cache = cache;
+    }
 
-        /// <summary>
-        /// Creates a new student in the timeline
-        /// </summary>
-        /// <param name="Request"></param>
-        /// <exception cref="ArgumentException"/>
-        /// <returns></returns>
-        public Task<TimelineStudent> CreateStudent(CreateTimelineStudentRequest Request);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="Request"></param>
-        /// <exception cref="ArgumentException"/>
-        /// <returns></returns>
-        public Task<TimelineStudent?> GetStudent(FindTimelineStudentRequest Request);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="Request"></param>
-        /// <returns></returns>
-        public Task<TimelineStudent?> DeleteStudent(string StudentId);
-
-        /// <summary>
-        /// Creates a new student in the timeline
-        /// </summary>
-        /// <param name="Request"></param>
-        /// <exception cref="ArgumentException"/>
-        /// <returns></returns>
-        public Task<TimelineTeam> CreateTeam(CreateTimelineTeamRequest Request);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="Request"></param>
-        /// <returns></returns>
-        public Task<TimelineTeam?> GetTeam(string TeamId);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="Request"></param>
-        /// <returns></returns>
-        public Task<TimelineTeam?> FindTeam(FindTimelineTeamRequest Request);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <returns></returns>
-        public Task<TimelineTeam?> DeleteTeam(string TeamId);
+    public async Task<IReadOnlyList<TimelineStudent>> GetStudentTimeline()
+    {
+      return await this.Database.GetAllDocuments<TimelineStudent>("Timeline/Collections/Students")
+                                  .ConfigureAwait(false);
 
     }
 
-    public class TimelineService : ITimelineService
+    public async Task<TimelineStudent> CreateStudent(CreateTimelineStudentRequest Request)
     {
 
-        private readonly IMemoryCache Cache;
-        private readonly IDatabaseService Database;
+      var NewStudent = new TimelineStudent
+      {
+        TimelineStudentId = Guid.NewGuid().ToString(),
+        StudentId = Request.StudentId,
+        FullName = Request.FullName,
+        Date = DateTime.UtcNow,
+        Title = Request.Title,
+        Description = Request.Description,
+      };
 
-        private static readonly MemoryCacheEntryOptions _timelinePersonCacheOptions = new MemoryCacheEntryOptions()
-        {
-            Size = 400,
-            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30)
-        };
+      var CreateTimelineStudentResult = await this.Database.Collection("Timeline")
+                                                           .Document("Collections")
+                                                           .Collection("Students")
+                                                           .Document(NewStudent.TimelineStudentId)
+                                                           .CreateDocumentAsync(NewStudent)
+                                                           .ConfigureAwait(false);
 
-        public TimelineService(IDatabaseService database, IMemoryCache cache)
+      this.Cache.Set($"TimelineStudent-{NewStudent.StudentId}", NewStudent, _timelinePersonCacheOptions);
+
+      return NewStudent;
+
+    }
+
+    public async Task<TimelineStudent> UpdateStudent(UpdateTimelineStudentRequest Request)
+    {
+
+      var student = await this.Database.Collection("Timeline")
+                                        .Document("Collections")
+                                        .Collection("Students")
+                                        .Document(Request.StudentTimelineId)
+                                        .GetDocumentAsync<TimelineStudent>()
+                                        .ConfigureAwait(false);
+
+      if (student != null)
+      {
+        // Prepare a list to store the updates
+        var updates = new List<(string, object)>();
+
+        if (Request.StudentId != null)
         {
-            Database = database;
-            Cache = cache;
+          updates.Add(("StudentId", Request.StudentId));
         }
 
-        public async Task<IReadOnlyList<CompanyTeamRestModel>> GetTimeline(GetTimelineRequest Request)
+        if (Request.FullName != null)
         {
-
-            var FilteredTeamNames = Request.TeamName?
-                                           .Split(',')
-                                           .Select(x => x.Trim());
-
-            var FilteredStudentIds = Request.StudentId?
-                                            .Split(',')
-                                            .Select(x => x.Trim())
-                                            .ToArray();
-
-            IReadOnlyList<TimelineStudent>? StudentQuery = null;
-
-            if (Request.StudentId is not null)
-            {
-
-                StudentQuery = await this.Database.Collection("Timeline")
-                                                  .Document("Collections")
-                                                  .Collection("Students")
-                                                  .WhereIn(FieldPath.DocumentId.ToString(), FilteredStudentIds)
-                                                  .GetAsync<TimelineStudent>();
-
-                // Filter the team names by the teams that the students belong to
-                if (FilteredTeamNames is not null)
-                {
-                    FilteredTeamNames = StudentQuery.SelectMany(x => x.Teams)
-                                                    .Distinct()
-                                                    .Where(x => FilteredTeamNames is null || FilteredTeamNames.Contains(x)).ToList();
-
-                    if (FilteredTeamNames.Any() is false)
-                        return new List<CompanyTeamRestModel>();
-
-                }
-
-            }
-
-            var TeamQuery = this.Database.Collection("Timeline")
-                                         .Document("Collections")
-                                         .Collection("Teams")
-                                         .WhereEqual(nameof(TimelineTeam.Trimester), Request.Trimester);
-
-            // No filter on Team Name. Return all teams.
-            if (FilteredTeamNames is not null)
-            {
-                // Select only teams with specific team names
-                TeamQuery = TeamQuery.WhereIn(nameof(TimelineTeam.TeamName), FilteredTeamNames);
-            }
-
-            var Teams = await TeamQuery.GetAsync<CompanyTeamRestModel>();
-
-            if (Teams.Any() is false)
-                return Teams;
-
-            StudentQuery ??= await this.Database.Collection("Timeline")
-                                                .Document("Collections")
-                                                .Collection("Students")
-                                                .WhereArrayContainsAny(nameof(TimelineStudent.Teams), Teams.Select(x => x.TeamId))
-                                                .GetAsync<TimelineStudent>();
-
-            foreach (var Team in Teams)
-                Team.Students = StudentQuery.Where(x => x.Teams.Contains(Team.TeamId)).ToList();
-
-            return Teams;
-
+          updates.Add(("FullName", Request.FullName));
         }
 
-        public async Task<TimelineStudent> CreateStudent(CreateTimelineStudentRequest Request)
+        if (Request.Title != null)
         {
-
-            var NewStudent = new TimelineStudent
-            {
-                StudentId = Guid.NewGuid().ToString(),
-                FullName = Request.FullName,
-                Role = Request.Role,
-                ProfilePicture = Request.ProfilePicture,
-                RemarkableAchievements = Request.RemarkableAchievements,
-                AreaOfSpecialization = Request.AreaOfSpecialization,
-                LinkedInProfile = Request.LinkedInProfile,
-            };
-
-            // If TeamName or TeamTrimester is specified
-            if (Request.Teams?.Any() is true)
-            {
-
-                NewStudent.Teams = Request.Teams.AsParallel().Select(async Team =>
-                {
-
-                    var StudentsTeam = await this.Database.Collection("Timeline")
-                                                          .Document("Collections")
-                                                          .Collection("Teams")
-                                                          .WhereEqual(nameof(Team.Trimester), Team.Trimester)
-                                                          .WhereEqual(nameof(Team.TeamName), Team.TeamName)
-                                                          .Limit(1)
-                                                          .GetAsync<TimelineTeam>()
-                                                          .ConfigureAwait(false);
-
-                    if (StudentsTeam.IsNullOrEmpty())
-                        throw new ArgumentException("There's no team name matching ", nameof(Team.TeamName));
-
-                    return StudentsTeam.First().TeamId;
-
-                }).ToArray().Select(x => x.ConfigureAwait(false).GetAwaiter().GetResult()).ToArray();
-
-            }
-
-            var CreateTimelineStudentResult = await this.Database.Collection("Timeline")
-                                                                 .Document("Collections")
-                                                                 .Collection("Students")
-                                                                 .Document(NewStudent.StudentId)
-                                                                 .CreateDocumentAsync(NewStudent)
-                                                                 .ConfigureAwait(false);
-
-            this.Cache.Set($"TimelineStudent-{NewStudent.StudentId}", NewStudent, _timelinePersonCacheOptions);
-
-            return NewStudent;
-
+          updates.Add(("Title", Request.Title));
         }
 
-        public async Task<TimelineStudent?> GetStudent(FindTimelineStudentRequest Request)
+        if (Request.Description != null)
         {
-
-            if (Request.StudentId is not null)
-            {
-
-                if (this.Cache.TryGetValue($"TimelineStudent-{Request.StudentId}", out TimelineStudent Student))
-                    return Student;
-                else
-                    return await this.Database.Collection("Timeline")
-                                              .Document("Collections")
-                                              .Collection("Students")
-                                              .Document(Request.StudentId)
-                                              .GetDocumentAsync<TimelineStudent>()
-                                              .ConfigureAwait(false);
-            }
-
-            else if (Request.StudentName is not null)
-                return (await this.Database.Collection("Timeline")
-                                              .Document("Collections")
-                                              .Collection("Students")
-                                              .WhereEqual(nameof(TimelineStudent.FullName), Request.StudentName)
-                                              .GetAsync<TimelineStudent>()
-                                              .ConfigureAwait(false))
-                                              .FirstOrDefault();
-
-            throw new ArgumentException("GetStudentRequest must have one field filled out", nameof(Request));
-
+          updates.Add(("Description", Request.Description));
         }
 
-        public async Task<TimelineStudent?> DeleteStudent(string StudentId)
-        {
+        // Update the document in the database
+        await this.Database.UpdateDocument<TimelineStudent>("Timeline/Collections/Students", Request.StudentTimelineId, updates.ToArray()).ConfigureAwait(false);
 
-            this.Cache.Remove($"TimelineStudent-{StudentId}");
+        // Get the updated student data
+        var updatedStudent = await this.Database.GetDocument<TimelineStudent>("Timeline/Collections/Students", Request.StudentTimelineId).ConfigureAwait(false);
+        return updatedStudent;
+      }
+      else
+      {
+        throw new ArgumentException("Student not found.");
+      }
+    }
 
-            return await this.Database.Collection("Timeline")
+    public async Task<TimelineStudent?> GetStudent(FindTimelineStudentRequest Request)
+    {
+
+      if (Request.StudentId is not null)
+      {
+
+        if (this.Cache.TryGetValue($"TimelineStudent-{Request.StudentId}", out TimelineStudent Student))
+          return Student;
+        else
+          return await this.Database.Collection("Timeline")
+                                    .Document("Collections")
+                                    .Collection("Students")
+                                    .Document(Request.StudentId)
+                                    .GetDocumentAsync<TimelineStudent>()
+                                    .ConfigureAwait(false);
+      }
+
+      else if (Request.StudentName is not null)
+        return (await this.Database.Collection("Timeline")
                                       .Document("Collections")
                                       .Collection("Students")
-                                      .Document(StudentId)
-                                      .DeleteDocumentAsync<TimelineStudent>();
+                                      .WhereEqual(nameof(TimelineStudent.FullName), Request.StudentName)
+                                      .GetAsync<TimelineStudent>()
+                                      .ConfigureAwait(false))
+                                      .FirstOrDefault();
 
-        }
-
-        public async Task<TimelineTeam> CreateTeam(CreateTimelineTeamRequest Request)
-        {
-
-            //
-            // Validate 
-
-            var TimelineTeam = new TimelineTeam
-            {
-                TeamId = Guid.NewGuid().ToString(),
-                Description = Request.Description,
-                Logo = Request.Logo,
-                Mentors = Request.Mentors,
-                PrototypeLink = Request.PrototypeLink,
-                TeamName = Request.TeamName,
-                Trimester = Request.Trimester,
-                VideoLink = Request.VideoLink
-            };
-
-            return await this.Database.Collection("Timeline")
-                                      .Document("Collections")
-                                      .Collection("Teams")
-                                      .Document(TimelineTeam.TeamId)
-                                      .SetDocumentAsync<TimelineTeam>(TimelineTeam);
-
-        }
-
-        public async Task<TimelineTeam?> GetTeam(string TeamId)
-        {
-
-            return await this.Database.Collection("Timeline")
-                                      .Document("Collections")
-                                      .Collection("Teams")
-                                      .Document(TeamId)
-                                      .GetDocumentAsync<TimelineTeam>();
-
-        }
-
-        public async Task<TimelineTeam?> FindTeam(FindTimelineTeamRequest Request)
-        {
-
-            return (await this.Database.Collection("Timeline")
-                                       .Document("Collections")
-                                       .Collection("Teams")
-                                       .WhereEqual(nameof(TimelineTeam.TeamName), Request.TeamName)
-                                       .WhereEqual(nameof(TimelineTeam.Trimester), Request.Trimester)
-                                       .GetAsync<TimelineTeam>()
-                                       .ConfigureAwait(false))
-                                       .FirstOrDefault();
-
-        }
-
-        public async Task<TimelineTeam?> DeleteTeam(string TeamId)
-        {
-
-            return await this.Database.Collection("Timeline")
-                                      .Document("Collections")
-                                      .Collection("Teams")
-                                      .Document(TeamId)
-                                      .DeleteDocumentAsync<TimelineTeam>();
-
-        }
+      throw new ArgumentException("GetStudentRequest must have one field filled out", nameof(Request));
 
     }
+
+    public async Task<TimelineStudent?> DeleteStudent(string StudentId)
+    {
+
+      this.Cache.Remove($"TimelineStudent-{StudentId}");
+
+      return await this.Database.Collection("Timeline")
+                                .Document("Collections")
+                                .Collection("Students")
+                                .Document(StudentId)
+                                .DeleteDocumentAsync<TimelineStudent>();
+
+    }
+
+    public async Task<TimelineTeam> CreateTeam(CreateTimelineTeamRequest Request)
+    {
+
+      //
+      // Validate
+
+      var TimelineTeam = new TimelineTeam
+      {
+        TeamId = Guid.NewGuid().ToString(),
+        Description = Request.Description,
+        Logo = Request.Logo,
+        Mentors = Request.Mentors,
+        PrototypeLink = Request.PrototypeLink,
+        TeamName = Request.TeamName,
+        Trimester = Request.Trimester,
+        VideoLink = Request.VideoLink
+      };
+
+      return await this.Database.Collection("Timeline")
+                                .Document("Collections")
+                                .Collection("Teams")
+                                .Document(TimelineTeam.TeamId)
+                                .SetDocumentAsync<TimelineTeam>(TimelineTeam);
+
+    }
+
+    public async Task<TimelineTeam?> GetTeam(string TeamId)
+    {
+
+      return await this.Database.Collection("Timeline")
+                                .Document("Collections")
+                                .Collection("Teams")
+                                .Document(TeamId)
+                                .GetDocumentAsync<TimelineTeam>();
+
+    }
+
+    public async Task<TimelineTeam?> FindTeam(FindTimelineTeamRequest Request)
+    {
+
+      return (await this.Database.Collection("Timeline")
+                                 .Document("Collections")
+                                 .Collection("Teams")
+                                 .WhereEqual(nameof(TimelineTeam.TeamName), Request.TeamName)
+                                 .WhereEqual(nameof(TimelineTeam.Trimester), Request.Trimester)
+                                 .GetAsync<TimelineTeam>()
+                                 .ConfigureAwait(false))
+                                 .FirstOrDefault();
+
+    }
+
+    public async Task<TimelineTeam?> DeleteTeam(string TeamId)
+    {
+
+      return await this.Database.Collection("Timeline")
+                                .Document("Collections")
+                                .Collection("Teams")
+                                .Document(TeamId)
+                                .DeleteDocumentAsync<TimelineTeam>();
+
+    }
+
+  }
 
 }

--- a/Monolith/ProjectX.WebAPI/Services/ITimelineService.cs
+++ b/Monolith/ProjectX.WebAPI/Services/ITimelineService.cs
@@ -64,6 +64,9 @@ namespace ProjectX.WebAPI.Services
     /// <returns></returns>
     public Task<TimelineTeam?> UpdateTeam(UpdateTimelineTeamRequest Request);
 
+    public Task<IReadOnlyList<TimelineTeam>> GetAllTeamTimelines();
+
+
     /// <summary>
     ///
     /// </summary>
@@ -228,6 +231,13 @@ namespace ProjectX.WebAPI.Services
                                 .Collection("Students")
                                 .Document(StudentTimelineId)
                                 .DeleteDocumentAsync<TimelineStudent>();
+
+    }
+
+     public async Task<IReadOnlyList<TimelineTeam>> GetAllTeamTimelines()
+    {
+      return await this.Database.GetAllDocuments<TimelineTeam>("Timeline/Collections/Teams")
+                                  .ConfigureAwait(false);
 
     }
 

--- a/Monolith/ProjectX.WebAPI/appsettings.json
+++ b/Monolith/ProjectX.WebAPI/appsettings.json
@@ -8,5 +8,12 @@
   "AllowedHosts": "*",
   "ApplicationHosting": {
     "ExternalUrl": "https://api.gopherindustries.net"
+  },
+  "ApplicationIdentity": {
+    "AccessJWTSecret": "N3k1aXp0bVd3TjNwRlN2QzJFZ1lRdHpHZnZWUW9SaUk=",
+    "RefreshJWTSecret": "7Lg2rqTAJZS625jcsNW8HNgB3lwyt1vMvAgb9lB7"
+  },
+  "ApplicationHash": {
+    "HashingPepper": "J7JT5z1OJRhbjDW7JsybgPIyjy5THsq8sDcUSLgRMz0l2vIRlr"
   }
 }


### PR DESCRIPTION
This PR does several things:

- Allow `EmailVerified` to be optional to remove an error
- Move `Pepper` into the secrets file
- Fix AuthModel bug: the database was previously storing `UserAuthentication` as a duplicate of `User`, instead of storing hashedPassword and fields used to decrypt the password
- Change default port to port 8000 as 80 tend to cause port conflicts error